### PR TITLE
Timestep variable name as parameter

### DIFF
--- a/odetoolbox/__init__.py
+++ b/odetoolbox/__init__.py
@@ -121,7 +121,10 @@ def analysis(indict):
         print("  " + ode["symbol"], end="")
         if ode["is_linear_constant_coefficient"]:
             print(": analytical")
-            output = compute_analytical_solution(ode["symbol"], ode["definition"], shapes)
+            if "timestep_symbol_name" in indict.keys():
+                output = compute_analytical_solution(ode["symbol"], ode["definition"], shapes, timestep_symbol_name=indict["timestep_symbol_name"])
+            else:
+                output = compute_analytical_solution(ode["symbol"], ode["definition"], shapes)
         else:
             print(": numerical ", end="")
             output = compute_numeric_solution(shapes)

--- a/odetoolbox/analytic.py
+++ b/odetoolbox/analytic.py
@@ -50,7 +50,7 @@ class Propagator(object):
 
     """
 
-    def __init__(self, ode_symbol, ode_definition, shapes):
+    def __init__(self, ode_symbol, ode_definition, shapes, timestep_symbol_name="__h"):
 
         self.ode_symbol = parse_expr(ode_symbol)
         self.ode_definition = parse_expr(ode_definition)
@@ -58,7 +58,7 @@ class Propagator(object):
         self.step_constant = Symbol("")
         self.propagator = None
         self.ode_updates = None
-        
+        self._timestep_symbol = Symbol(timestep_symbol_name)
         constant_input, step_constant = self._compute_propagator_matrices(shapes)
         self._compute_propagation_step(shapes, constant_input, step_constant)
 
@@ -85,23 +85,23 @@ class Propagator(object):
         larger than 2, we calculate A by choosing the state variables
         canonically as y_0 = shape^(n), ..., y_{n-1} = shape, y_n = V
         """
-        
+
         # Initialize the factor in front of the ode symbol, an empty
         # list to hold the factors for the shapes and a symbol to
         # represent the time step.
         ode_symbol_factor = diff(self.ode_definition, self.ode_symbol)
         shape_factors = []
-        h = Symbol("__h")
-        
+        h = self._timestep_symbol
+
         if not shapes:
             print("ERROR: no shapes given, unable to calculate the propagator matrix.")
             import sys
             sys.exit(1)
 
         for shape in shapes:
-    
+
             shape_factor = diff(self.ode_definition, shape.symbol)
-    
+
             if shape.order == 1:
                 A = Matrix([[shape.derivative_factors[0], 0],
                             [shape_factor, ode_symbol_factor]])
@@ -166,10 +166,10 @@ class Propagator(object):
             shape.state_updates = P[:shape.order, :shape.order] * y[:shape.order, 0]
 
 
-def compute_analytical_solution(ode_symbol, ode_definition, shapes):
+def compute_analytical_solution(ode_symbol, ode_definition, shapes, timestep_symbol_name="__h"):
 
-    propagator = Propagator(ode_symbol, ode_definition, shapes)
-    
+    propagator = Propagator(ode_symbol, ode_definition, shapes, timestep_symbol_name=timestep_symbol_name)
+
     data = {
         "solver": "analytical",
         "ode_updates": propagator.ode_updates,

--- a/odetoolbox/stiffness.py
+++ b/odetoolbox/stiffness.py
@@ -77,7 +77,7 @@ class StiffnessTester(object):
         state_start_values_tmp = {}
         thresholds_tmp = []
 
-        self.parameters = {k:float(v) for k,v in indict["parameters"].iteritems()}
+        self.parameters = {k:float(v) for k,v in indict["parameters"].items()}
 
         for shape in indict["shapes"]:
             shape_name = shape["symbol"]
@@ -158,7 +158,7 @@ class StiffnessTester(object):
 
         """
 
-        odes = sorted(self.ode_definitions.iteritems())
+        odes = sorted(self.ode_definitions.items())
         state_vars = [parse_expr(k, local_dict=self.parameters) for k,v in odes]
         ode_defs = [parse_expr(v, local_dict=self.parameters) for k,v in odes]
 
@@ -431,6 +431,6 @@ class StiffnessTester(object):
         except Exception as e:
             print("E==>", type(e).__name__ + ": " + str(e))
             print("     Local parameters at time of failure:")
-            for k,v in local_parameters.iteritems():
+            for k,v in local_parameters.items():
                 print("    ", k, "=", v)
             raise


### PR DESCRIPTION
Allow the user to explicitly specify the timestep variable name. This was hard-coded as `__h`, but when computing propagators for an arbitrary timestep (e.g. from the arrival time of one spike to the next), a value different from the simulation resolution is necessary.

Additional minor fix for Python3 compatibility (replace `dict.iteritems()` by `dict.items()`).